### PR TITLE
Support CLI

### DIFF
--- a/bin/support
+++ b/bin/support
@@ -1,0 +1,2 @@
+#! /usr/bin/env node
+require('../lib/cli')()(process.argv.slice(2))

--- a/lib/cli/commands/badges.js
+++ b/lib/cli/commands/badges.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = function (opts) {
+  return {
+    command: 'badges',
+    desc: 'Output badges markdown based on support',
+    builder: function (yargs) {
+      return yargs
+    },
+    handler: function (argv) {
+      argv.log.info('badges')
+    }
+  }
+}

--- a/lib/cli/commands/setup.js
+++ b/lib/cli/commands/setup.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = function (opts) {
+  return {
+    command: 'setup',
+    desc: 'Setup a support declaration for a package',
+    builder: function (yargs) {
+      return yargs
+    },
+    handler: function (argv) {
+      argv.log.info('setup')
+    }
+  }
+}

--- a/lib/cli/commands/show.js
+++ b/lib/cli/commands/show.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = function (opts) {
+  return {
+    command: 'show',
+    desc: 'Show support information',
+    builder: function (yargs) {
+      return yargs
+    },
+    handler: function (argv) {
+      argv.log.info('show')
+    }
+  }
+}

--- a/lib/cli/commands/validate.js
+++ b/lib/cli/commands/validate.js
@@ -16,8 +16,11 @@ module.exports = function (opts) {
     },
     handler: async function (argv) {
       let userPackageJson
+      let packageJsonPath
       try {
-        userPackageJson = await fs.readJSON(path.join(process.cwd(), 'package.json'))
+        const jsonFile = path.join(process.cwd(), 'package.json')
+        packageJsonPath = path.dirname(jsonFile)
+        userPackageJson = await fs.readJSON(jsonFile)
       } catch (error) {
         argv.log.error(error)
         return
@@ -34,10 +37,10 @@ module.exports = function (opts) {
       let { support } = userPackageJson
 
       if (support === true) {
-        support = await fs.readJSON(path.join(process.cwd(), 'package-support.json'))
+        support = await fs.readJSON(path.join(packageJsonPath, 'package-support.json'))
       } else if (typeof support === 'string') {
-        const p = path.join(process.cwd(), support)
-        if (!pathContains(process.cwd(), p)) {
+        const p = path.join(packageJsonPath, support)
+        if (!pathContains(packageJsonPath, p)) {
           throw new Error('Support string path must be contained in cwd')
         }
         support = await fs.readJSON()

--- a/lib/cli/commands/validate.js
+++ b/lib/cli/commands/validate.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const fs = require('fs-extra')
+const path = require('path')
+const pathContains = require('contains-path')
+const Ajv = require('ajv')
+
+const supportSchema = require('./../../../schema.json')
+
+module.exports = function (opts) {
+  return {
+    command: 'validate',
+    desc: 'Validate support information schema',
+    builder: function (yargs) {
+      return yargs
+    },
+    handler: async function (argv) {
+      let userPackageJson
+      try {
+        userPackageJson = await fs.readJSON(path.join(process.cwd(), 'package.json'))
+      } catch (error) {
+        argv.log.error(error)
+        return
+      }
+
+      const ajv = new Ajv({
+        // coerceTypes: true,
+        useDefaults: true,
+        removeAdditional: true,
+        allErrors: true,
+        nullable: true
+      })
+
+      let { support } = userPackageJson
+
+      if (support === true) {
+        support = await fs.readJSON(path.join(process.cwd(), 'package-support.json'))
+      } else if (typeof support === 'string') {
+        const p = path.join(process.cwd(), support)
+        if (!pathContains(process.cwd(), p)) {
+          throw new Error('Support string path must be contained in cwd')
+        }
+        support = await fs.readJSON()
+      } else if (typeof support === 'object') {
+        // TODO check for the repository obj and get the support info via HTTP:
+        // https://docs.npmjs.com/files/package.json#repository
+      }
+
+      const validate = ajv.compile(supportSchema)
+      const result = validate(support)
+      if (result) {
+        argv.log.info('Your support information is valid!')
+        return
+      }
+      // TODO show better errors
+      argv.log.error('validate: ', validate.errors)
+    }
+  }
+}

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,0 +1,89 @@
+'use strict'
+const yargs = require('yargs/yargs')
+const path = require('path')
+const Loggerr = require('loggerr')
+
+module.exports = (options = {}) => {
+  // Defaults cli configuration
+  const opts = Object.assign({
+    commandsDir: path.join(__dirname, 'commands'),
+    usage: '$0 <command> [options]',
+    silentLevel: -1,
+    verboseLevel: 'info',
+    logLevel: 'error',
+    logger: (level) => {
+      return new Loggerr({
+        formatter: 'cli',
+        level: level
+      })
+    },
+    fail: (msg) => {
+      log.error(msg)
+      console.log()
+      cli.showHelp()
+      process.exit(1)
+    }
+  }, options)
+
+  // The log instance
+  const log = opts.logger(opts.logLevel)
+
+  // Setup yargs cli instance
+  const cli = yargs()
+
+    // Log related flags
+    .option('log-level', {
+      alias: 'l',
+      describe: 'Set the log level',
+      type: 'string',
+      group: 'Logging:',
+      defaultDescription: opts.logLevel
+    })
+    .option('silent', {
+      alias: 'S',
+      describe: 'Surpress all output',
+      type: 'boolean',
+      group: 'Logging:'
+    })
+    .option('verbose', {
+      alias: 'v',
+      describe: `Verbose output (alias of --log-level=${opts.verboseLevel})`,
+      type: 'boolean',
+      group: 'Logging:'
+    })
+    .conflicts({
+      verbose: 'silent',
+      silent: 'verbose',
+      'log-level': ['silent', 'verbose']
+    })
+
+    .middleware([
+      // Log setup
+      (argv) => {
+        if (argv.silent) {
+          argv.logLevel = opts.silentLevel
+        } else if (argv.verbose) {
+          argv.logLevel = opts.verboseLevel
+        }
+        log.setLevel(argv.logLevel)
+        argv.log = log
+      }
+    ])
+
+    .commandDir(opts.commandsDir, {
+      visit: (mod) => typeof mod === 'function' ? mod(opts) : mod
+    })
+    .usage(opts.usage)
+    .command('$0', 'Show help', {}, (argv) => {
+      !argv.silent && cli.showHelp()
+    })
+
+  cli.wrap(Math.min(cli.terminalWidth(), 120))
+
+  // on fail callback
+  if (typeof opts.fail === 'function') {
+    cli.fail(opts.fail)
+  }
+
+  return (argv) => cli.parse(argv)
+}

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41,7 +41,7 @@ module.exports = (options = {}) => {
     })
     .option('silent', {
       alias: 'S',
-      describe: 'Surpress all output',
+      describe: 'Supress all output',
       type: 'boolean',
       group: 'Logging:'
     })

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41,7 +41,7 @@ module.exports = (options = {}) => {
     })
     .option('silent', {
       alias: 'S',
-      describe: 'Supress all output',
+      describe: 'Suppress all output',
       type: 'boolean',
       group: 'Logging:'
     })

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "test": "standard && mocha --delay",
-    "prepublushOnly": "npm t",
+    "prepublishOnly": "npm t",
     "postpublish": "git push origin && git push origin --tags"
   },
   "dependencies": {
@@ -48,5 +48,8 @@
     "fs-extra": "^8.1.0",
     "mocha": "^6.2.0",
     "standard": "^14.0.2"
+  },
+  "engines": {
+    "node": "^14 || ^13 || ^12 || ^11 || ^10 || ^8 || ^6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ajv": "^6.11.0",
     "contains-path": "^1.0.0",
     "loggerr": "^3.0.0-0",
+    "through2-spy": "^2.0.0",
     "yargs": "^14.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "https://github.com/pkgjs/support.git"
   },
+  "bin": {
+    "support": "./bin/support"
+  },
   "support": {
     "versions": [
       {
@@ -36,7 +39,10 @@
     "postpublish": "git push origin && git push origin --tags"
   },
   "dependencies": {
-    "ajv": "^6.10.2"
+    "ajv": "^6.11.0",
+    "contains-path": "^1.0.0",
+    "loggerr": "^3.0.0-0",
+    "yargs": "^14.0.0"
   },
   "devDependencies": {
     "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "test": "standard && mocha --delay",
-    "prepublishOnly": "npm t",
+    "prepublishOnly": "npm test",
     "postpublish": "git push origin && git push origin --tags"
   },
   "dependencies": {

--- a/schema.json
+++ b/schema.json
@@ -82,7 +82,7 @@
           "active",
           "lts_active",
           "lts_latest",
-          "maintained",
+          "supported",
           "current"
         ]
       }, {
@@ -97,7 +97,7 @@
         "type": {
           "oneOf": [{
             "type": "string",
-            "enum": [ "none", "best-effort", "24-7" ]
+            "enum": [ "none", "time-permitting", "best-effort", "24-7" ]
           }, {
             "type": "string",
             "pattern": "regular-[1-7]"

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,31 @@
+
+'use strict'
+const { suite, test, run } = require('mocha')
+const assert = require('assert')
+const Loggerr = require('loggerr')
+const spy = require('through2-spy')
+const cli = require('../lib/cli')
+
+suite('cli validate', async () => {
+  test('check this support information', (done) => {
+    const logChecker = spy({ wantStrings: true }, function (chunk) {
+      try {
+        assert.ok(/information is valid/.test(chunk))
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+
+    cli({
+      logger: () => {
+        return new Loggerr({
+          formatter: 'cli',
+          streams: Loggerr.levels.map(() => logChecker)
+        })
+      }
+    })(['validate'])
+  })
+
+  run()
+})


### PR DESCRIPTION
A command line interface for operating on support metadata.  This is a work in progress PR, and will probably be the last to merge once the js api is finalized.

**TODO:**

- [ ] Setup a support declaration
- [ ] Validate the support schema
- [ ] Output badges markdown from support metadata
- [ ] Show support information
  - [ ] List specific fields from schema
  - [ ] List all support url's from install tree
  - [ ] List information for remote packages
