### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 When an author releases an Open Source package there are many different levels
 of support they may intend to provide.  The [Node.js Package Maintenence Working Group](https://github.com/nodejs/package-maintenance)
-is working to propse [a spec](https://github.com/nodejs/package-maintenance/issues/220) to help package authors delcare their intended support goals.  This package provides
+is working to propse [a spec](https://github.com/nodejs/package-maintenance/issues/220) to help package authors declare their intended support goals.  This package provides
 some tooling around working with the format proposed.
 
 ## Project Status
@@ -37,11 +37,11 @@ const pkgJson = require('./package.json')
 try {
   support.validate(pkgJson.support)
 } catch (e) {
-  // Validateion failure
+  // Validation failure
   // The error is annotated with the
   // errors and schema from `ajv`
   console.error(e)
-  console.log(e.validateionErrors)
-  console.log(e.validateionSchema)
+  console.log(e.validationErrors)
+  console.log(e.validationSchema)
 }
 ```


### PR DESCRIPTION
Fixing a few minor typos in README (example code now matches implementation spelling).