### PR TITLE
Update CI in order to drop Node 8.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,16 @@
 name: Test
-on: push
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/cli/commands/show.js
+++ b/lib/cli/commands/show.js
@@ -22,6 +22,9 @@ async function printModule (module, depth, argv) {
     console.log(`${' '.repeat(2 * (depth + 1))}${moduleInfo} - ${supportInfo.url}`)
   }
 
+  // sort child modules
+  module.children = new Map([...module.children.entries()].sort())
+
   // print info for all of the child modules
   for (const child of module.children.values()) {
     await printModule(child, depth + 1, argv)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postpublish": "git push origin && git push origin --tags"
   },
   "dependencies": {
-    "@npmcli/arborist": "0.0.0-pre.19",
+    "@npmcli/arborist": "^0.0.0",
     "ajv": "^6.11.0",
     "better-ajv-errors": "^0.6.7",
     "got": "^11.1.3",


### PR DESCRIPTION
@mhdawson
Following discussion #9 - I tried to migrate from `got` to other http lib but found another dependency without support for 8.x which we can't replace:

`npm-registry-fetch` [uses optional catch binding](https://github.com/npm/npm-registry-fetch/blob/latest/check-response.js#L38) and it's failing. So yeah, it looks like we can not go with 8.x

This PR:
- removes 8.x from CI
- adds 14.x to CI as we might want to test it on future LTS
- adds running CI for pull requests
- updates `arborist` to fresh version
- fixes `show` command modules ordering

Closes #9 