### PR TITLE
fix so that show works for non-nested cases

### DIFF
--- a/lib/cli/commands/show.js
+++ b/lib/cli/commands/show.js
@@ -40,7 +40,7 @@ module.exports = function (opts) {
     },
     handler: function (argv) {
       const arb = new Arborist()
-      arb.loadActual().then(root => {
+      arb.buildIdealTree({ legacyBundling: true }).then(root => {
         printModule(root, 0, argv).then(() => {}, (e) => {
           argv.log.error('show failed: ', e)
         })


### PR DESCRIPTION
- found writing starting on doc that the show command
did not work as expected for cases where the node_modules
directories were not nested based on dependencies.

- building the ideal tree with the legacy option fixes
this

Signed-off-by: Michael Dawson <michael_dawson@ca.ibm.com>

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
