### PR TITLE
suppress error when no command specified

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -18,7 +18,6 @@ module.exports = (options = {}) => {
       });
     },
     fail: (msg) => {
-      log.error(msg);
       console.log();
       cli.showHelp();
       process.exit(1);


### PR DESCRIPTION
yargs will show the help by default when no command is specified.
The error message makes to think that it is a bug in support tool.

Related to #23 
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
