### PR TITLE
fix: update show-separate-repo-fetch test

### DIFF
--- a/test/cli/show-separate-repo-fetch/expected
+++ b/test/cli/show-separate-repo-fetch/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo(0.0.1) - { "versions": [{ "version": "*", "target": { "node": "lts" }, "response": { "type": "best-effort" }, "backing": { "hobby": "https://github.com/pkgjs/support" } }]}
+  @pkgjs/support-separate-repo(0.0.1) - { "versions": [{ "version": "*", "target": { "node": "lts" }, "response": { "type": "time-permitting" }, "backing": { "hobby": "https://github.com/pkgjs/support" } }]}


### PR DESCRIPTION
This updates the expected file by changing the value from best-effort
to time-permitting. Since the test will fetch the value from github,
we need this in order to have test without fail.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
