### PR TITLE
rename branch master to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Test
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ of support they may intend to provide.  The [Node.js Package Maintenance Working
 is working to propose [a spec](https://github.com/nodejs/package-maintenance/blob/HEAD/docs/PACKAGE-SUPPORT.md) to help package authors declare their intended support goals.  This package provides
 some tooling around working with the format proposed.
 
-This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/master/Governance.md).
+This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/main/Governance.md).
 
 ## Command line usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ of support they may intend to provide.  The [Node.js Package Maintenance Working
 is working to propose [a spec](https://github.com/nodejs/package-maintenance/blob/HEAD/docs/PACKAGE-SUPPORT.md) to help package authors declare their intended support goals.  This package provides
 some tooling around working with the format proposed.
 
-This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/main/Governance.md).
+This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/HEAD/Governance.md).
 
 ## Command line usage
 

--- a/doc/command-line-usage.md
+++ b/doc/command-line-usage.md
@@ -116,7 +116,7 @@ npx @pkgjs/support show --canonical
 ```
 
 where the support info is listed as 
-`https://github.com/pkgjs/support/blob/main/package-support.json`
+`https://github.com/pkgjs/support/blob/HEAD/package-support.json`
 
 The --canonical option does not automatically pull the remote information so that the
 consumer can choose to find the locations without automatically triggering a number of
@@ -151,7 +151,7 @@ of the package, the tool will simply print the url from which the support inform
 can be obtained versus displaying it. For example:
 
 ```
-@pkgjs/support-show-local-escape-ok(0.0.1) - https://github.com/pkgjs/support/blob/main/my-support-info.json
+@pkgjs/support-show-local-escape-ok(0.0.1) - https://github.com/pkgjs/support/blob/HEAD/my-support-info.json
 ```
 
 where the `support` entry was:
@@ -205,7 +205,7 @@ If the support information is not available locally or you have specified
 `--canonical` without `--fetch` you'll see something like:
 
 ```shell
-support info not resolved: https://github.com/pkgjs/support/blob/main/package-support.json
+support info not resolved: https://github.com/pkgjs/support/blob/HEAD/package-support.json
 ```
 
 in this case the file is local to the package, but --canonical was specified. The same

--- a/doc/command-line-usage.md
+++ b/doc/command-line-usage.md
@@ -18,7 +18,7 @@ you can run the support tool using `npx @pkgjs/support`.
 
 The support tool helps package consumers review and understand the
 package support information provided by maintainers. See
-[Package-support.md](https://github.com/nodejs/package-maintenance/blob/master/docs/PACKAGE-SUPPORT.md)
+[Package-support.md](https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md)
 which documents the suggested best practice and the specific format of the
 package support information.
 
@@ -97,7 +97,7 @@ npx @pkgjs/support show --canonical
 
 
 ```
-@pkgjs/support(0.0.2) - https://github.com/pkgjs/support/blob/master/package-support.json
+@pkgjs/support(0.0.2) - https://github.com/pkgjs/support/blob/main/package-support.json
     @npmcli/arborist(0.0.0) - unknown
       @npmcli/installed-package-contents(1.0.5) - unknown
         npm-bundled(1.1.1) - unknown
@@ -116,7 +116,7 @@ npx @pkgjs/support show --canonical
 ```
 
 where the support info is listed as 
-`https://github.com/pkgjs/support/blob/master/package-support.json`
+`https://github.com/pkgjs/support/blob/main/package-support.json`
 
 The --canonical option does not automatically pull the remote information so that the
 consumer can choose to find the locations without automatically triggering a number of
@@ -151,7 +151,7 @@ of the package, the tool will simply print the url from which the support inform
 can be obtained versus displaying it. For example:
 
 ```
-@pkgjs/support-show-local-escape-ok(0.0.1) - https://github.com/pkgjs/support/blob/master/my-support-info.json
+@pkgjs/support-show-local-escape-ok(0.0.1) - https://github.com/pkgjs/support/blob/main/my-support-info.json
 ```
 
 where the `support` entry was:
@@ -177,7 +177,7 @@ The `validate` command checks that both the information added to the package.jso
 and the file containing the support info (package-support.json by default) is valid.
 
 
-[Integration into package.json](https://github.com/nodejs/package-maintenance/blob/master/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
+[Integration into package.json](https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
 explains the options for providing support info and what goes into the package.json for
 each case.
 
@@ -185,7 +185,7 @@ each case.
 Depending the how the `support` section in the package.json is configured validate will:
 
 * validate the format of the `support` section in the package.json conforms to the
-documentation in [Integration into package.json](https://github.com/nodejs/package-maintenance/blob/master/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
+documentation in [Integration into package.json](https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
 * calculate the file which contains the support info
 * if the file is available locally, use that data unless the `--canonical`
   option was specified.
@@ -205,7 +205,7 @@ If the support information is not available locally or you have specified
 `--canonical` without `--fetch` you'll see something like:
 
 ```shell
-support info not resolved: https://github.com/pkgjs/support/blob/master/package-support.json
+support info not resolved: https://github.com/pkgjs/support/blob/main/package-support.json
 ```
 
 in this case the file is local to the package, but --canonical was specified. The same

--- a/doc/command-line-usage.md
+++ b/doc/command-line-usage.md
@@ -18,7 +18,7 @@ you can run the support tool using `npx @pkgjs/support`.
 
 The support tool helps package consumers review and understand the
 package support information provided by maintainers. See
-[Package-support.md](https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md)
+[Package-support.md](https://github.com/nodejs/package-maintenance/blob/HEAD/docs/PACKAGE-SUPPORT.md)
 which documents the suggested best practice and the specific format of the
 package support information.
 
@@ -97,7 +97,7 @@ npx @pkgjs/support show --canonical
 
 
 ```
-@pkgjs/support(0.0.2) - https://github.com/pkgjs/support/blob/main/package-support.json
+@pkgjs/support(0.0.2) - https://github.com/pkgjs/support/blob/HEAD/package-support.json
     @npmcli/arborist(0.0.0) - unknown
       @npmcli/installed-package-contents(1.0.5) - unknown
         npm-bundled(1.1.1) - unknown

--- a/doc/command-line-usage.md
+++ b/doc/command-line-usage.md
@@ -185,7 +185,7 @@ each case.
 Depending the how the `support` section in the package.json is configured validate will:
 
 * validate the format of the `support` section in the package.json conforms to the
-documentation in [Integration into package.json](https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
+documentation in [Integration into package.json](https://github.com/nodejs/package-maintenance/blob/HEAD/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
 * calculate the file which contains the support info
 * if the file is available locally, use that data unless the `--canonical`
   option was specified.

--- a/doc/command-line-usage.md
+++ b/doc/command-line-usage.md
@@ -177,7 +177,7 @@ The `validate` command checks that both the information added to the package.jso
 and the file containing the support info (package-support.json by default) is valid.
 
 
-[Integration into package.json](https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
+[Integration into package.json](https://github.com/nodejs/package-maintenance/blob/HEAD/docs/PACKAGE-SUPPORT.md#integration-into-packagejson)
 explains the options for providing support info and what goes into the package.json for
 each case.
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports.validate = (obj, cli = false) => {
 
 // extract the URL for the support info from the pkg info
 module.exports.getRemoteSupportInfoUrl = (repository, supportPath) => {
-  const gitHubInitialPath = '/blob/master/';
+  const gitHubInitialPath = '/blob/HEAD/';
 
   if (repository && (repository.type === 'git')) {
     const directory = repository.directory || '';

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/pkgjs/support/master/schema.json",
+  "$id": "https://raw.githubusercontent.com/pkgjs/support/main/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Package Support Information",
 

--- a/support-element-schema.json
+++ b/support-element-schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/pkgjs/support/master/support-element-schema.json",
+  "$id": "https://raw.githubusercontent.com/pkgjs/support/main/support-element-schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Package Support Package.json element",
 

--- a/test/cli/show-local-escape/expected
+++ b/test/cli/show-local-escape/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-show-local-escape(0.0.1) - https://github.com/pkgjs/support/blob/master/my-support-info.json
+  @pkgjs/support-show-local-escape(0.0.1) - https://github.com/pkgjs/support/blob/HEAD/my-support-info.json

--- a/test/cli/show-local-path2/expected
+++ b/test/cli/show-local-path2/expected
@@ -1,1 +1,1 @@
-  @pkgjs/show-local-path2(0.0.1) - https://github.com/pkgjs/show-local-path2/blob/master/subdir/my-support-info.json
+  @pkgjs/show-local-path2(0.0.1) - https://github.com/pkgjs/show-local-path2/blob/HEAD/subdir/my-support-info.json

--- a/test/cli/show-separate-repo-directory1/expected
+++ b/test/cli/show-separate-repo-directory1/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo-directory1(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/master/subdir2/my-support-package.json
+  @pkgjs/support-separate-repo-directory1(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/subdir2/my-support-package.json

--- a/test/cli/show-separate-repo-directory2/expected
+++ b/test/cli/show-separate-repo-directory2/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo-directory2(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/master/subdir2/package-support.json
+  @pkgjs/support-separate-repo-directory2(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/subdir2/package-support.json

--- a/test/cli/show-separate-repo-directory3/expected
+++ b/test/cli/show-separate-repo-directory3/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo-directory3(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/master/subdir2/subdir1/my-support-package.json
+  @pkgjs/support-separate-repo-directory3(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/subdir2/subdir1/my-support-package.json

--- a/test/cli/show-separate-repo-fetch-missing/expected-errors
+++ b/test/cli/show-separate-repo-fetch-missing/expected-errors
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo(0.0.1) - failed to fetch - https://github.com/pkgjs/support/blob/master/examples/does-not-exist.json
+  @pkgjs/support-separate-repo(0.0.1) - failed to fetch - https://github.com/pkgjs/support/blob/HEAD/examples/does-not-exist.json

--- a/test/cli/show-separate-repo-path1/expected
+++ b/test/cli/show-separate-repo-path1/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo-path1(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/master/my-support-package.json
+  @pkgjs/support-separate-repo-path1(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/my-support-package.json

--- a/test/cli/show-separate-repo-path2/expected
+++ b/test/cli/show-separate-repo-path2/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo-path2(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/master/subdir1/my-support-package.json
+  @pkgjs/support-separate-repo-path2(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/subdir1/my-support-package.json

--- a/test/cli/show-separate-repo/expected
+++ b/test/cli/show-separate-repo/expected
@@ -1,1 +1,1 @@
-  @pkgjs/support-separate-repo(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/master/package-support.json
+  @pkgjs/support-separate-repo(0.0.1) - https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/package-support.json

--- a/test/cli/validate-local-repository1/expected-errors
+++ b/test/cli/validate-local-repository1/expected-errors
@@ -1,1 +1,1 @@
-support info not resolved: https://github.com/pkgjs/support-separate-repo-other/blob/master/subdir2/my-support-package.json
+support info not resolved: https://github.com/pkgjs/support-separate-repo-other/blob/HEAD/subdir2/my-support-package.json

--- a/test/cli/validate-non-resolved/expected-errors
+++ b/test/cli/validate-non-resolved/expected-errors
@@ -1,1 +1,1 @@
-support info not resolved: https://github.com/pkgjs/support/blob/master/package-support.json
+support info not resolved: https://github.com/pkgjs/support/blob/HEAD/package-support.json


### PR DESCRIPTION
Renamed the `master` branch to `main` following the [GitHub guide](https://github.blog/changelog/2021-01-19-support-for-renaming-an-existing-branch/)

To update your local repository run:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
```

Ref https://github.com/nodejs/package-maintenance/issues/445

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
